### PR TITLE
Avoid node v20 deprecation warnings and allow users to pick a specific version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,5 +14,5 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,27 @@ on:
 
 jobs:
   test:
-    name: 'Test ${{ matrix.os }}'
+    name: 'Test ${{ matrix.os }} / ${{ matrix.case.name }}'
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        case:
+          - name: latest
+            version: latest
+            expected: ''
+          - name: pinned
+            version: 25.4.2.044.1837
+            expected: 25.4.2.044.1837
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: ./
+        with:
+          version: ${{ matrix.case.version }}
+      - name: Assert SQLcl version
+        if: ${{ matrix.case.expected != '' }}
+        shell: bash
+        run: |
+          sql -version | tee version.txt
+          grep -F "${{ matrix.case.expected }}" version.txt

--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,9 @@ Following inputs may be used as `step.with` keys:
 | setup-java-version |          | 21       | Automatically setup Oracle JDK with the chosen version. Set to `false` to skip it.
 |===
 
-NOTE: If you decide to skip the automatic Java setup then you'll be responsible for configuring Java with version `11` as a minimum.
+The action accepts `version: latest` to download Oracle's current SQLcl build, or a fully qualified release in the form `nn.n.n.nnn.nnnn`, such as `25.3.0.274.1210`.
+
+NOTE: If you decide to skip the automatic Java setup then you'll be responsible for configuring Java with version `11` as a minimum. Newer SQLcl releases require Java 17 and later.
 We recommend using link:https://github.com/actions/setup-java[actions/setup-java].
 
 == Usage
@@ -56,5 +58,4 @@ jobs:
 
 == Versions
 
-The full list of supported SQLcl versions can be found link:https://github.com/gvenzl/setup-oracle-sqlcl/blob/main/versions.txt[here].
-Use `version: latest` (default & recommended) to always pull the latest release of SQLcl or use an explicit version of SQLcl to pin it for reproducible builds.
+Use `version: latest` (default & recommended) to always pull the latest release of SQLcl or use an explicit version of SQLcl to pin it for reproducible builds. The latter is advisable especially when using the action in SQLcl project workflows to pin the SQLcl version to the one used in your configuration.

--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: {project-owner}/{project-name}@{project-tag}
       - name: Run SQLcl
         run: |

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2025 Gerald Venzl, Andres Almiray
+# Copyright 2026 Gerald Venzl, Andres Almiray, Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ branding:
 
 inputs:
   version:
-    description: 'The SQLCl version to download.'
+    description: 'The SQLcl version to download: latest or a fully qualified release like 25.4.2.044.1837'
     default: 'latest'
     required: true
 
@@ -37,7 +37,7 @@ runs:
   using: 'composite'
   steps:
     - name: 'Setup Java'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       if: ${{ inputs.setup-java-version != 'false' }}
       with:
         java-version: ${{ inputs.setup-java-version }}

--- a/setup_sqlcl.sh
+++ b/setup_sqlcl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2025 Gerald Venzl, Andres Almiray
+# Copyright 2026 Gerald Venzl, Andres Almiray, Martin Bach
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,28 +19,26 @@ set -e
 
 echo "::group::⬇️ Download SQLcl"
 
-# Download well-known latest version of SQLcl
 if [[ ${VERSION} == "latest" ]]; then
-  curl -s -o "sqlcl.zip" "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-latest.zip"
+
+  # Download well-known latest version of SQLcl (default)
+  curl --fail --location --show-error --silent --retry 3 \
+    -o "sqlcl.zip" \
+    "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-latest.zip"
+
+elif [[ "${VERSION}" =~ ^[0-9]{2}\.[0-9]+\.[0-9]+\.[0-9]{3}\.[0-9]{4}$ ]]; then
+
+  # Download a specific version, use the fully qualified release name like
+  # in homebrew
+  download_link="https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-${VERSION}.zip"
+  curl --fail --location --show-error --silent --retry 3 \
+    -o "sqlcl.zip" \
+    "${download_link}"
 else
-  # Version download page
-  download_page="https://www.oracle.com/sqlcl/download/sqlcl-downloads-${VERSION}.html"
-
-  # Check whether download page exists
-  http_code=$(curl -s -L -o /dev/null -w "%{http_code}" "${download_page}")
-
-  if [[ "${http_code}" != "200" ]]; then
-    echo "❌ SQLcl version '${VERSION}' could not be resolved."
-    echo "Make sure that the version exists!"
-    exit 1;
-  fi;
-
-  # Getting the download page based on the version
-  download_link=$(curl -L -s "${download_page}" | grep "https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-${VERSION}" | grep -oP 'href="\K[^"]+')
-
-  # Download SQLcl
-  curl -s -o "sqlcl.zip" "${download_link}"
-
+  # incorrect version specified
+  echo "❌ SQLcl version '${VERSION}' is not valid."
+  echo "Make sure that the version exists!"
+  exit 1;
 fi;
 
 echo "::endgroup::"
@@ -53,7 +51,7 @@ unzip -qo "sqlcl.zip"
 echo "SQLCL_HOME=${PWD}/sqlcl" >> "$GITHUB_ENV"
 
 # State version
-${PWD}/sqlcl/bin/sql -version
+"${PWD}/sqlcl/bin/sql" -version
 
 echo "${PWD}/sqlcl/bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
This PR addresses 2 issues:

- node v20 based actions are deprecated and will be disabled in June 2026
  - this action uses checkout@v4 and setup-java@v4
  - they are both candidates for deprecation
  - wherever possible the most current versions have been used instead

- Users couldn't specify a specific SQLcl version to be installed
  - Oracle [SQLcl projects](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.4/sqcug/database-application-ci-cd.html) workflow is based on a specific SQLcl release
  - if the SQLcl runtime doesn't match the one specified in `.dbtools/project.config.json` a deployment will fail
  - it is important that users can specify a matching SQLcl version to ensure consistent deployments
  - the logic employed in the action now matches that found in [homebrew](https://formulae.brew.sh/cask/sqlcl)

Smaller changes include an updated readme and the addition of a couple extra tests to ensure both the latest SQLcl can be deployed as well as a specific version